### PR TITLE
fix: correct footer and provenance contrast

### DIFF
--- a/assets/css/seo-contrast.css
+++ b/assets/css/seo-contrast.css
@@ -17,15 +17,15 @@
 .source-note {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 1.5rem;
-  align-items: center;
+  gap: 0.65rem 2rem;
+  align-items: flex-start;
   margin: 1.25rem 0 0;
-  padding: 1rem 1.2rem;
-  border: 1px solid var(--border);
+  padding: 1.1rem 1.25rem;
+  border: 1px solid #aebbb4;
   border-radius: 1rem;
   background: #fff;
-  color: #435149;
-  font-size: 0.9rem;
+  color: #33423b;
+  font-size: 0.925rem;
   line-height: 1.55;
 }
 
@@ -65,7 +65,6 @@
 
 .archive-notice strong,
 .section--green .eyebrow,
-.site-footer__links h2,
 .metric-strip strong,
 .document-card__type {
   color: var(--lime-on-dark);
@@ -75,18 +74,50 @@
 .section--green .section-heading > p,
 .system-flow p,
 .link-card--primary p,
-.story-card__content p,
+.story-card__content p {
+  color: var(--muted-on-dark);
+}
+
+/* Footer uses a light canvas, so all inherited dark-surface colours are reset. */
+.site-footer,
+.site-footer__body {
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+.site-footer .site-brand,
+.site-footer .site-brand__text strong,
+.site-footer .site-brand__text small,
 .site-footer__about p,
+.site-footer__links h2,
 .site-footer__links a,
 .site-footer__bottom {
-  color: var(--muted-on-dark);
+  color: var(--ink);
+}
+
+.site-footer__about p,
+.site-footer__bottom {
+  color: #435149;
+}
+
+.site-footer__links h2 {
+  color: var(--green-900);
+}
+
+.site-footer__links a {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
 }
 
 .site-footer__links a:hover,
 .site-footer__links a:focus-visible {
-  color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
+  color: #083126;
+  text-decoration-thickness: 2px;
+}
+
+.site-footer__bottom {
+  border-top-color: #87948d;
 }
 
 .page-hero__media figcaption {
@@ -144,6 +175,6 @@ input::placeholder {
 @media (max-width: 720px) {
   .source-note {
     display: grid;
-    gap: 0.45rem;
+    gap: 0.55rem;
   }
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -10,6 +10,9 @@ const contrastPairs = [
   ['primary text on canvas', '#111c16', '#f3f0e7', 4.5],
   ['muted text on canvas', '#53615a', '#f3f0e7', 4.5],
   ['muted text on white', '#53615a', '#ffffff', 4.5],
+  ['provenance text on white', '#33423b', '#ffffff', 4.5],
+  ['footer secondary text on canvas', '#435149', '#f3f0e7', 4.5],
+  ['footer heading on canvas', '#0d3b2e', '#f3f0e7', 4.5],
   ['white text on green', '#ffffff', '#0d3b2e', 4.5],
   ['lime text on dark green', '#d8f36f', '#082d23', 4.5],
   ['dark-section secondary text', '#c6d7cf', '#082d23', 4.5],
@@ -136,6 +139,9 @@ async function validateCss(failures) {
   expect(/\.page-hero__media img\s*\{[^}]*position\s*:\s*absolute/s.test(theme), 'agri-theme.css: hero image does not cover its figure', failures);
   expect(!theme.includes('fonts.googleapis.com'), 'agri-theme.css: unused Google Fonts request found', failures);
   expect(contrast.includes('.metric-strip .source-note strong'), 'seo-contrast.css: provenance labels inherit metric styling', failures);
+  expect(contrast.includes('.site-footer__links h2'), 'seo-contrast.css: footer heading contrast override is missing', failures);
+  expect(contrast.includes('.site-footer__about p'), 'seo-contrast.css: footer body contrast override is missing', failures);
+  expect(contrast.includes('color: #33423b'), 'seo-contrast.css: provenance body colour is not explicit', failures);
   expect(contrast.includes(':focus-visible'), 'seo-contrast.css: visible focus treatment is missing', failures);
   contrastPairs.forEach(([name, foreground, background, minimum]) => {
     const ratio = contrastRatio(foreground, background);


### PR DESCRIPTION
## What changed

- Corrected the shared footer palette on the cream canvas across every published page.
- Replaced inherited pale-on-dark footer colours with dark green headings, dark body text, visible underlined links, and a clearer divider.
- Increased provenance-note body text contrast and strengthened its border against white.
- Kept lime text limited to genuinely dark surfaces such as the metric strip and dark sections.
- Added automated WCAG contrast checks for provenance text, footer secondary text, and footer headings.
- Added source-level assertions so the footer and provenance overrides cannot be removed unnoticed.

## Root cause

The redesigned footer uses the light cream canvas, but the shared contrast stylesheet still grouped footer text with dark-section text. The provenance note had dark labels, while its descriptive text remained too pale on white.

## Scope

This is a focused follow-up to PR #29. It changes only the shared contrast stylesheet and repository validator. Layout, content, navigation, and JavaScript behavior are unchanged.

## Validation

- Branch starts from the current merged `master`.
- Zero commits behind `master`.
- GitHub Actions and the Vercel preview will be confirmed before review.